### PR TITLE
Remove cursor: pointer from the header

### DIFF
--- a/dist/sass/_nav.scss
+++ b/dist/sass/_nav.scss
@@ -338,7 +338,6 @@ header {
   height: 260px;
   right: 0;
   z-index: 1000;
-  cursor: pointer;
   overflow: hidden;
   -webkit-transform: translate(0,0);
   -moz-transform: translate(0,0);


### PR DESCRIPTION
Hello!

The new website is looking super smart, great work. :dancer: 

I noticed the header has cursor: pointer on it which makes the entire navigation highlight when interacting with it on Chrome for Android.

![screenshot_2014-11-11-19-30-12](https://cloud.githubusercontent.com/assets/2445413/4999416/12f7e5d6-69da-11e4-9eab-afb299b19a46.png)
