### PR TITLE
Fix links in Getting Started, referenced in issue #115

### DIFF
--- a/intro/index.html
+++ b/intro/index.html
@@ -117,13 +117,13 @@ redirect_from: "/intro.html"
         <li>You can also try our tutorial in which you'll learn how to work with Hoodie's store and accounts. Just do your Hoodie setup, then run <strong>hoodie new yourAppName -t gr2m/hoodie-store-and-account-tutorial</strong> and try it out!
         </li>
         <li>
-            Find out how to create a new Hoodie app, how its admin interface works, how Hoodie projects are structured and more in our tutorial <a href="https://github.com/hoodiehq/documentation/blob/gh-pages/tutorials/getting-started/getting-started-1.md" target="_blank">"Getting started with Hoodie, part 1"</a>.
+            Find out how to create a new Hoodie app, how its admin interface works, how Hoodie projects are structured and more in our tutorial <a href="http://docs.hood.ie/start/getting-started/getting-started-1.html" target="_blank">"Getting started with Hoodie, part 1"</a>.
         </li>
         <li>
             Get creative and build your own app!
         </li>
         <li>
-            If you need to take a quick look at Hoodie's different commands: here's our handy <a href="/dist/presentations/hoodie-cheat-sheet.pdf">Hoodie Cheat Sheet</a> (and here's its <a href="/dist/presentations/hoodie-cheat-sheet-print">Print Version</a>).
+            If you need to take a quick look at Hoodie's different commands: here's our handy <a href="https://github.com/hoodiehq/hoodie.js/blob/master/CheatSheet.md">Hoodie Cheat Sheet</a> (and here's its <a href="/dist/presentations/hoodie-cheat-sheet-print.pdf">Print Version</a>).
         </li>
         <li>
             Should you need any help or have questions: find out how to <a href=/get-help>get help</a>, give us <a href="/contribute/#feedback">feedback</a>, and, of course, <a href="/contact">we’re there for you</a>.

--- a/intro/index.html
+++ b/intro/index.html
@@ -109,7 +109,7 @@ redirect_from: "/intro.html"
     </h1>
     <ol>
         <li>
-        Get the <a href="http://docs.hood.ie/start/" target="_blank">prerequisites</a>.
+        Get the <a href="http://docs.hood.ie/en/start/" target="_blank">prerequisites</a>.
         </li>
         <li>
             Follow our guides for getting started <a href="https://github.com/hoodiehq/documentation/blob/gh-pages/start/index.md#installation-on-mac-os-x" target="_blank">Mac OS X</a>, <a href="https://github.com/hoodiehq/documentation/blob/gh-pages/start/index.md#installation-on-windows" target="_blank">Windows</a> or <a href=https://github.com/hoodiehq/documentation/blob/gh-pages/start/index.md#installation-on-linux-ubuntu" target="_blank">Linux</a>.
@@ -117,7 +117,7 @@ redirect_from: "/intro.html"
         <li>You can also try our tutorial in which you'll learn how to work with Hoodie's store and accounts. Just do your Hoodie setup, then run <strong>hoodie new yourAppName -t gr2m/hoodie-store-and-account-tutorial</strong> and try it out!
         </li>
         <li>
-            Find out how to create a new Hoodie app, how its admin interface works, how Hoodie projects are structured and more in our tutorial <a href="http://docs.hood.ie/start/getting-started/getting-started-1.html" target="_blank">"Getting started with Hoodie, part 1"</a>.
+            Find out how to create a new Hoodie app, how its admin interface works, how Hoodie projects are structured and more in our tutorial <a href="http://docs.hood.ie/en/start/getting-started/getting-started-1.html" target="_blank">"Getting started with Hoodie, part 1"</a>.
         </li>
         <li>
             Get creative and build your own app!


### PR DESCRIPTION
Fixed links for Getting started with Hoodie part 1, Hoodie Cheat Sheet, and Hoodie Cheat Sheet print version.  

Previously, the Getting Started and Cheat Sheet Print links did not work, and the Hoodie Cheat Sheet link took you to the print version.
