### PR TITLE
Fixed plugin tutorial link.

### DIFF
--- a/contribute/index.html
+++ b/contribute/index.html
@@ -177,7 +177,7 @@ title: hood.ie contribute
             <a name="plugins" class="jump-mark">Build Plugins to extend Hoodie’s core functionalities</a>
         </h1>
         <p>
-            Hoodie’s main features like user signup and administration, data storage and shares are all <a href="http://nodejs.org" target="_blank">Node.js</a>-based plugins which are <!-- <a href="https://github.com/hoodiehq/documentation/blob/gh-pages/tutorials/how-hoodie-works-behind-the-magic.md" target="_blank">-->added to its core code<!--</a>-->. All currently available Hoodie-Plugins are <a href="http://plugins.hood.ie" target="_blank">here</a>. We encourage you to <strong>write your own plugins</strong> and publish them on npm so everyone can use them. In <a href="http://docs.hood.ie/en/plugins/plugins-tutorial.html" target="_blank">this tutorial</a> you’ll see how building plugins works. If you need any help, <a href="/contact">let us know</a>.
+            Hoodie’s main features like user signup and administration, data storage and shares are all <a href="http://nodejs.org" target="_blank">Node.js</a>-based plugins which are <!-- <a href="https://github.com/hoodiehq/documentation/blob/gh-pages/tutorials/how-hoodie-works-behind-the-magic.md" target="_blank">-->added to its core code<!--</a>-->. All currently available Hoodie-Plugins are <a href="http://plugins.hood.ie" target="_blank">here</a>. We encourage you to <strong>write your own plugins</strong> and publish them on npm so everyone can use them. In <a href="http://docs.hood.ie/en/plugins/tutorial.html" target="_blank">this tutorial</a> you’ll see how building plugins works. If you need any help, <a href="/contact">let us know</a>.
         </p>
     </article>
     <aside class="contribute-aside-icon">

--- a/intro/index.html
+++ b/intro/index.html
@@ -26,7 +26,7 @@ redirect_from: "/intro.html"
             Hoodie is a free and Open Source Software for building applications for the web and iOS. It is a complete backend for your apps, <strong>ready for you to get creative</strong>. It works immediately out-of-the-box: develop your frontend code, plug it into Hoodie’s <a href="/intro#get-started">frontend-friendly API</a> and your app is ready.
         </p>
         <p>
-            When you develop it, your app runs locally first, you can then <a href="http://docs.hood.ie/en/deployment/linux.html" target="_blank">deploy and host it</a> wherever you want to. And if you want to extend Hoodie’s core features, you can check our list of <a href="http://plugins.hood.ie" target="_blank">currently available plugins</a> or <a href="http://docs.hood.ie/en/plugins/plugins-tutorial.html" target="_blank">build plugins</a> yourself.
+            When you develop it, your app runs locally first, you can then <a href="http://docs.hood.ie/en/deployment/linux.html" target="_blank">deploy and host it</a> wherever you want to. And if you want to extend Hoodie’s core features, you can check our list of <a href="http://plugins.hood.ie" target="_blank">currently available plugins</a> or <a href="http://docs.hood.ie/en/plugins/tutorial.html" target="_blank">build plugins</a> yourself.
         </p>
         <p>
             Hoodie is a <a href="/initiatives#nobackend">noBackend</a> technology — it's there for making the lives of frontend developers easier by <strong>abstracting away the backend</strong> and keeping you from worrying about backends. It gives you <a href="/initiatives#dreamcode">Dreamcode</a>: a simple, easy-to-learn-and-implement frontend API built into it. Hoodie is also <a href="/initiatives#offline-first">Offline First</a>, which means that your app users’ data is stored locally by default so your Hoodie-based apps are accessible and usable anytime, independent from your users’ internet connection.
@@ -63,7 +63,7 @@ redirect_from: "/intro.html"
     <article class="grid-9">
         <h1 class="h2">Hoodie gives you a backend for all your apps</h1>
         <p>
-            If Hoodie’s core features aren’t enough for you, you can extend Hoodie with plugins, so you can make Hoodie fit your needs exactly. See all our <a href="http://plugins.hood.ie" target="_blank">currently available plugins here</a> and out how to build a plugin yourself in <a href="http://docs.hood.ie/en/plugins/plugins-tutorial.html" target="_blank">this tutorial</a>.
+            If Hoodie’s core features aren’t enough for you, you can extend Hoodie with plugins, so you can make Hoodie fit your needs exactly. See all our <a href="http://plugins.hood.ie" target="_blank">currently available plugins here</a> and out how to build a plugin yourself in <a href="http://docs.hood.ie/en/plugins/tutorial.html" target="_blank">this tutorial</a>.
         </p>
     </article>
 </div>
@@ -71,7 +71,7 @@ redirect_from: "/intro.html"
     <article class="grid-9">
         <h1 class="h2">Hoodie is currently for frontend developers and Node.js developers</h1>
         <p>
-            At the moment, Hoodie is mainly for frontend developers who want to build their own applications based on it and for Node.js developers who want to help us extend Hoodie’s core by <a href="http://docs.hood.ie/en/plugins/plugins-tutorial.html" target="_blank">building plugins</a>.
+            At the moment, Hoodie is mainly for frontend developers who want to build their own applications based on it and for Node.js developers who want to help us extend Hoodie’s core by <a href="http://docs.hood.ie/en/plugins/tutorial.html" target="_blank">building plugins</a>.
         </p>
         <p>
             Hoodie’s <strong>vision</strong> and future goal is to be accessible for designers and people with few coding skills because <a href="/about#philosophy">we think this matters</a>.


### PR DESCRIPTION
Changed dead link http://docs.hood.ie/en/plugins/plugins-tutorial.html to http://docs.hood.ie/en/plugins/tutorial.html.
