### PR TITLE
Fix getting started guide, add npm scripts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
+gem 'jekyll'
 gem 'github-pages'

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Hood.ie: the Website for the Hoodie Open Source Project
 
 ## Getting started
 
-To get started check out the recent version and type `npm install`. You also need
-[Jekyll](http://jekyllrb.com/) installed. Then type `npm start` to start a local server on `localhost:1337`.
+To get started check out the recent version and type `npm installbundle` and `bundle`. 
+Then type `npm start` to start a local server on `localhost:1337`.
 This will run Grunts default task, so if you have `grunt-cli` installed globally you can also type `grunt` instead.
 
 There's also a production task (`npm run build` or `grunt build`) which at this point just spits out a compressed CSS file, without sourcemap in a dedicated folder(css/build).

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@ Hood.ie: the Website for the Hoodie Open Source Project
 
 ## Getting started
 
-To get started check out the recent version and type npm install.
-The default task (just type 'grunt') will fire up a local server at localhost:1337 with livereload and dev Sass compiling (including sourcemap and nested output).
-There's also a production task ('grunt build') which at this point just spits out a compressed CSS file, without sourcemap in a dedicated folder(css/build).
+To get started check out the recent version and type `npm install`. You also need
+[Jekyll](http://jekyllrb.com/) installed. Then type `npm start` to start a local server on `localhost:1337`.
+This will run Grunts default task, so if you have `grunt-cli` installed globally you can also type `grunt` instead.
+
+There's also a production task (`npm run build` or `grunt build`) which at this point just spits out a compressed CSS file, without sourcemap in a dedicated folder(css/build).
 
 ## FE structure overview
 

--- a/_layouts/layout-index.html
+++ b/_layouts/layout-index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js">
+<html lang="en" class="no-js">
 {% include head.html %}
     <body class="orange index">
         {% include header.html %}

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -4,9 +4,9 @@ module.exports = function(grunt) {
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
-    jekyll: {
-      options: {
-        bundleExec: true
+    shell: {
+      jekyllBuild: {
+        command: 'bundle exec jekyll build'
       }
     },
     connect: {
@@ -127,11 +127,11 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-string-replace');
-  grunt.loadNpmTasks('grunt-jekyll');
+  grunt.loadNpmTasks('grunt-shell');
   
 
   grunt.registerTask('default', [
-      'jekyll',
+      'shell',
       'connect',
       'string-replace:dev',
       'watch'

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -4,10 +4,16 @@ module.exports = function(grunt) {
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
+    jekyll: {
+      options: {
+        bundleExec: true
+      }
+    },
     connect: {
       server: {
         options: {
           port: 1337,
+          base: '_site'
         }
       }
     },
@@ -121,9 +127,12 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-string-replace');
+  grunt.loadNpmTasks('grunt-jekyll');
+  
 
   grunt.registerTask('default', [
-      // 'connect',
+      'jekyll',
+      'connect',
       'string-replace:dev',
       'watch'
     ]);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-jekyll": "^0.4.2",
     "grunt-sass": "^0.18.1",
     "grunt-string-replace": "^1.0.0",
     "time-grunt": "^1.0.0"
@@ -22,8 +23,5 @@
     "name": "Hood.ie Sass/JS",
     "stylesheets": "dist/sass",
     "javascripts": "dist/js"
-  },
-  "dependencies": {
-    "grunt-jekyll": "^0.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,22 +1,29 @@
 {
   "name": "hoodie-website",
   "version": "0.1.0",
+  "scripts": {
+    "start": "grunt",
+    "build": "grunt build"
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^1.0.1",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-connect": "^0.8.0",
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-sass": "^0.14.2",
+    "grunt-sass": "^0.18.1",
     "grunt-string-replace": "^1.0.0",
     "time-grunt": "^1.0.0"
   },
-
   "frontend": {
     "name": "Hood.ie Sass/JS",
     "stylesheets": "dist/sass",
     "javascripts": "dist/js"
+  },
+  "dependencies": {
+    "grunt-jekyll": "^0.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-jekyll": "^0.4.2",
     "grunt-sass": "^0.18.1",
+    "grunt-shell": "^1.1.2",
     "grunt-string-replace": "^1.0.0",
     "time-grunt": "^1.0.0"
   },


### PR DESCRIPTION
Hey,

the getting started guide was out of date. Basically what was missing was that you needed to have `jekyll` installed and run it and not only the grunt task. Also it didn't say that you needed to have `grunt` installed.

I now added a jekyll grunt task so that `grunt` is again enough to start a local server. I also added npm scripts, so that someone who wants to contribute just needs to type `npm start` to start a local server, which will use the locally installed `grunt-cli`, so no need to have grunt on your system.

Probably it would also be good to improve the watch task a bit, so that it also watches the html files for jekyll?

Best,
Finn
