### PR TITLE
fix(get-help): invalid link

### DIFF
--- a/get-help/index.html
+++ b/get-help/index.html
@@ -32,7 +32,7 @@ title: 'hood.ie get help'
     <article>
         <h2>Learn how to get started</h2>
         <ul>
-            <li>Go to the <a href="http://docs.hood.ie/start/" target="_blank">Prerequisites</a> for all Operating Systems.</li>
+            <li>Go to the <a href="http://docs.hood.ie/en/start/" target="_blank">Prerequisites</a> for all Operating Systems.</li>
             <li>Follow our complete guide for <a href="/intro#get-started">getting started</a>!</li>
         </ul>
     </article>


### PR DESCRIPTION
Hi,

the link http://docs.hood.ie/start/ returns a 404 error.

have a nice day
Christoph
