### PR TITLE
fix (documentation) add sample blog post

### DIFF
--- a/_drafts/post-sample.md
+++ b/_drafts/post-sample.md
@@ -1,0 +1,26 @@
+---
+
+title: 'Empty Title Post'
+author: Charlotte
+layout: blog-post
+comments: true
+
+---
+
+Hello!
+
+This is a sample post. How is the weather today?
+
+# A heading!
+
+More text about wonderful Hoodie things.
+
+# Commentary of awesome
+
+This thing, is awesome!
+
+_Have a lovely day :)_
+
+
+
+


### PR DESCRIPTION
The README says to copy the sample blog post `post-sample.md` when writing a draft post; but it doesn't actually exist.

Now, it does.

:tada:
