### PR TITLE
Grammar fix: "everyone" to "every one"

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -12,7 +12,7 @@ title: hood.ie about
             Hoodie is built by amazing <a href="/community">people</a> and is powered by strong core values.
         </p>
         <p>
-            The reason why Hoodie exists is that <a href="/community">everyone involved in this project</a> wants to <strong>help make the web a better place for everyone</strong>, and everyone of us is convinced that <strong>web development should be accessible to as many people as possible</strong>.
+            The reason why Hoodie exists is that <a href="/community">everyone involved in this project</a> wants to <strong>help make the web a better place for everyone</strong>, and every one of us is convinced that <strong>web development should be accessible to as many people as possible</strong>.
         </p>
         <p>
             Hoodie is based on strong core principles and eventual goals which are embedded in everything we do in this project. We think that <strong>these values are inevitable</strong> when we want to ensure that the web and the way we develop it can have a future.


### PR DESCRIPTION
contextually, "every one" makes more sense, because it indicates _each individual_ of a group, rather than the group as a whole.
