### PR TITLE
fix(sponsoring): remove gratipay from sponsor methods

### DIFF
--- a/contribute/index.html
+++ b/contribute/index.html
@@ -331,10 +331,6 @@ title: hood.ie contribute
         <p>
             We offer a <strong>sponsoring package for companies who are hiring new employees</strong> (or just want to sponsor us). Find more details on our <a href="/sponsoring">sponsoring page</a>.
         </p>
-        <h2 class="h5">Send us a Gratipay</h2>
-        <p>
-            Do you want to send us a <strong>small sum on a regular basis</strong>? We have a <a href="https://gratipay.com/hoodiehq" target="_blank">Gratipay account</a> and are grateful for donations there.
-        </p>
     </article>
     <aside class="contribute-aside-icon">
         <br />


### PR DESCRIPTION
I went to try and sponsor hoodie on gratipay, but it seems someone closed the account.
This PR removes this option of sponsoring from our contributing page.

It would be good to find another solution to receive small regular payments like this; I am sure there are a lot of people (like myself) who would like to donate but can't afford the $1000 of a sponsorship slot :smile: 
