### PR TITLE
Updates links to Hoodie Keynote presentations

### DIFF
--- a/contribute/index.html
+++ b/contribute/index.html
@@ -261,8 +261,8 @@ title: hood.ie contribute
             Do you like Hoodie and now want to tell other people about it? Wow, that’s amazing to hear! We know that preparing talks takes a lot of time. To support you and lower your efforts, <strong>we have prepared some talks about Hoodie for you</strong>, including presenter notes. Just click on the format of your choice, download them, adjust them to your needs and help us spread the word! Our currently available talks are (zip archive including fonts):
         </p>
         <ul>
-            <li>"One million Cheesecakes — Getting started with Hoodie": <a href="/dist/presentations/hoodie-intro_key.zip" target="_blank">Keynote</a></li>
-            <li>"Coding the Dream: Getting started with Hoodie and Offline First": <a href="/dist/presentations/coding-the-dream_key.zip" target="_blank">Keynote</a></li>
+            <li>"One million Cheesecakes — Getting started with Hoodie": <a href="/dist1/presentations/hoodie-intro_key.zip" target="_blank">Keynote</a></li>
+            <li>"Coding the Dream: Getting started with Hoodie and Offline First": <a href="/dist1/presentations/coding-the-dream_key.zip" target="_blank">Keynote</a></li>
         </ul>
         <p>
             If you're interested in other talks or topics, you'll find all our past talks, usually with slides, in <a href="/events">this list</a>. If you then would like to present one of them yourself, please <a href="/contact">contact us</a>.


### PR DESCRIPTION
This section of the Contribute page:

<img width="851" alt="screen shot 2015-10-01 at 6 06 52 pm" src="https://cloud.githubusercontent.com/assets/3051193/10235086/3851e412-6867-11e5-8813-1202557367c5.png">

contains broken links to open-source presentations about Hoodie (which I love). I updated the links to point to the new `dist1/` directory for all site assets. 
