### PR TITLE
[WIP] refactor: Add classnames so that we can remove element selectors

### DIFF
--- a/_layouts/blog-post-tgif-ish.html
+++ b/_layouts/blog-post-tgif-ish.html
@@ -6,7 +6,7 @@
         <div class="content blog blog-post">
             <section class="cb">
                 <article>
-                    <h1>{{ page.title }}</h1>
+                    <h1 class="uppercase">{{ page.title }}</h1>
                     <div class="blog-meta">
                         <time>
                             {{ page.date | date: "%B %e, %Y" }}

--- a/_layouts/blog-post-tgif.html
+++ b/_layouts/blog-post-tgif.html
@@ -6,7 +6,7 @@
         <div class="content blog blog-post">
             <section class="cb">
                 <article>
-                    <h1>{{ page.title }}</h1>
+                    <h1 class="uppercase">{{ page.title }}</h1>
                     <div class="blog-meta">
                         <time>
                             {{ page.date | date: "%B %e, %Y" }}

--- a/_layouts/blog-post.html
+++ b/_layouts/blog-post.html
@@ -6,7 +6,7 @@
         <div class="content blog blog-post">
             <section class="cb">
                 <article>
-                    <h1>{{ page.title }}</h1>
+                    <h1 class="uppercase">{{ page.title }}</h1>
                     <div class="blog-meta">
                         <time>
                             {{ page.date | date: "%B %e, %Y" }}

--- a/blog/index.html
+++ b/blog/index.html
@@ -10,7 +10,7 @@ title: 'hood.ie blog'
     {% for post in paginator.posts %}
         <section class="cb">
         <article class="blog-post-excerpt">
-            <h1>
+            <h1 class="uppercase">
                 <a class="blog-post-link" href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
             </h1>
             <div class="blog-meta">


### PR DESCRIPTION
We're not getting rid of the corresponding element selectors until this is merged and we've run our regression tests on CSS with the element selectors removed, pre-commit.

This is just WIP (work in progress), and will need to see the CSS changes in hoodiehq/hoodie-css#46 to make sense, will change to RFR (ready for review) when I've completed my changes in the `blog.scss` file, then I'll wait for reviews, then it can be set to RFM (ready for merge), and merged as appropriate.

Edit: Need to close this because when we convert the markdown to html I can't add classes there. Element selectors will have to stay in the `blog` scope until we can figure out a better way.
