### PR TITLE
Removed extra closing `</cite>`

### DIFF
--- a/_posts/2016-08-19-email-heaven-redefines-education-tgif-97.md
+++ b/_posts/2016-08-19-email-heaven-redefines-education-tgif-97.md
@@ -55,7 +55,7 @@ comments: false
 
 <cite>Anil Dash, in [There Is No Tech Industry](https://medium.com/humane-tech/there-is-no-technology-industry-44774dfb3ed7#.y7ctu7r0w)</cite>
 
-[Nobody Cares How Hard You Work](http://99u.com/articles/51908/nobody-cares-how-hard-you-work)</cite>
+[Nobody Cares How Hard You Work](http://99u.com/articles/51908/nobody-cares-how-hard-you-work)
 
 [Two Big Reasons Why Work Culture Is Overrated](http://www.fastcompany.com/3062899/hr/two-big-reasons-why-work-culture-is-overrated)
 


### PR DESCRIPTION
There is a `</cite>` to much, visible on the webpage:

![email heaven redefines education tgif 97 2016-08-22 16-59-35](https://cloud.githubusercontent.com/assets/971072/17859425/d96e3fee-6889-11e6-9757-a41dce3e4655.png)
