### PR TITLE
Remove broken link to an external image

### DIFF
--- a/intro/index.html
+++ b/intro/index.html
@@ -139,7 +139,7 @@ redirect_from: "/intro.html"
     <article class="grid-9">
         <h1 class="h2">Hoodie runs locally and can be hosted</h1>
         <p>
-            If you want your Hoodie-based applications to not just run locally, you can deploy them. Find all details on how to do this in <a href="https://github.com/hoodiehq/my-first-hoodie/blob/master/deployment.md" target="_blank">this tutorial</a>. <em>(Oh yes, <a href="http://s3-ec.buzzfed.com/static/enhanced/web05/2012/2/21/16/enhanced-buzz-wide-6382-1329860109-8.jpg" target="_blank">unfortunately</a>, deployments aren't really easy yet. We're working on making this much more smooth than it's now. If you want to help us with this, please <a href="/contact">get in touch with us</a>!)</em>
+            If you want your Hoodie-based applications to not just run locally, you can deploy them. Find all details on how to do this in <a href="https://github.com/hoodiehq/my-first-hoodie/blob/master/deployment.md" target="_blank">this tutorial</a>. <em>(Oh yes, unfortunately, deployments aren't really easy yet. We're working on making this much more smooth than it's now. If you want to help us with this, please <a href="/contact">get in touch with us</a>!)</em>
         </p>
     </article>
 </div>


### PR DESCRIPTION
I was going to replace the link, but it seems better to just remove it.
1.  Users will assume the link helps to explain or detail the issue or someone's experience with it.
2. Linking to a bare image asset, even in a hyperlink, doesn't seem like good practice, akin to — but not as egregious as — hotlinking.
3. Linking to the image in context (e.g., lightboxed on a gallery page on the source website) seems like overkill just to include a cute image.
