### PR TITLE
Update to freenode help link

### DIFF
--- a/chat/index.html
+++ b/chat/index.html
@@ -53,7 +53,7 @@ redirect_from: "/irc/"
 
         <h2>These are the guidelines:</h2>
          <p>
-             We're a small team and can't always be here, but we still want to make it easy to get in touch with us. We're usually here on weekdays between <strong>14:00 CE(S)T</strong> and <strong>18:00 CE(S)T</strong>.<span class="offsetMessage"></span>. If you've never used IRC before, you can find all information on how to use it, get a nick name and join a channel <a href="https://freenode.net/kb/answer/chat" target="_blank">here</a>.
+             We're a small team and can't always be here, but we still want to make it easy to get in touch with us. We're usually here on weekdays between <strong>14:00 CE(S)T</strong> and <strong>18:00 CE(S)T</strong>.<span class="offsetMessage"></span>. If you've never used IRC before, you can find all information on how to use it, get a nick name and join a channel <a href="https://freenode.net/kb/all" target="_blank">here</a>.
          </p>
          <p>We also have an <a href="http://faq.hood.ie" target="_blank">FAQ</a> for the most common questions. We also have special pages for <a href="/bug">Bug Reports</a> and various resources where you can <a href="/get-help">get help</a>. And, in general, we’re of course on the internet™ — you’ll find all the places where we are on <a href="/contact">our contact page</a>.</p>
     </article>

--- a/chat/index.html
+++ b/chat/index.html
@@ -53,7 +53,7 @@ redirect_from: "/irc/"
 
         <h2>These are the guidelines:</h2>
          <p>
-             We're a small team and can't always be here, but we still want to make it easy to get in touch with us. We're usually here on weekdays between <strong>14:00 CE(S)T</strong> and <strong>18:00 CE(S)T</strong>.<span class="offsetMessage"></span>. If you've never used IRC before, you can find all information on how to use it, get a nick name and join a channel <a href="https://freenode.net/using_the_network.shtml" target="_blank">here</a>.
+             We're a small team and can't always be here, but we still want to make it easy to get in touch with us. We're usually here on weekdays between <strong>14:00 CE(S)T</strong> and <strong>18:00 CE(S)T</strong>.<span class="offsetMessage"></span>. If you've never used IRC before, you can find all information on how to use it, get a nick name and join a channel <a href="https://freenode.net/kb/answer/chat" target="_blank">here</a>.
          </p>
          <p>We also have an <a href="http://faq.hood.ie" target="_blank">FAQ</a> for the most common questions. We also have special pages for <a href="/bug">Bug Reports</a> and various resources where you can <a href="/get-help">get help</a>. And, in general, we’re of course on the internet™ — you’ll find all the places where we are on <a href="/contact">our contact page</a>.</p>
     </article>


### PR DESCRIPTION
The link to the freenode help on the chat/index.html page was broken. I've updated to the link so should be working. 