### PR TITLE
nav header partialy hidden fix

### DIFF
--- a/dist1/css/hoodie.css
+++ b/dist1/css/hoodie.css
@@ -1556,7 +1556,7 @@ body.gray .animation.colorise .letter {
 
 header {
   cursor: pointer;
-  height: 102px;
+  height: 122px;
   overflow: hidden;
   position: absolute;
   right: 0;

--- a/dist1/sass/_nav.scss
+++ b/dist1/sass/_nav.scss
@@ -307,7 +307,7 @@ body {
 // TOP MENU LAYOUT
 header {
     cursor: pointer;
-    height: 102px;
+    height: 122px;
     overflow: hidden;
     position: absolute;
     right: 0;


### PR DESCRIPTION
Saw this error on Windows 10, Chrome 55

![nav header cuts off](http://i.imgur.com/kMZkgOs.png)