### PR TITLE
Change behaviour of cursor over header

### DIFF
--- a/dist1/css/hoodie.css
+++ b/dist1/css/hoodie.css
@@ -1555,7 +1555,6 @@ body.gray .animation.colorise .letter {
   overflow: hidden; }
 
 header {
-  cursor: pointer;
   height: 102px;
   overflow: hidden;
   position: absolute;


### PR DESCRIPTION
The cursor behaves as a pointer over the entire header though the entire header is not a hyperlink.
Fixes #351 