### PR TITLE
fix(index): link to newsletter form instead of embedding

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,15 +106,15 @@ hoodie.store.add({
                 </section>
             </div>
         </div>
-        <div class="row white">
-            <div class="grid-9 newsletter">
-                <div id="Mc_embed_signup">
+        <div class="row">
+            <div class="grid-9 m-l orange-box center newsletter">
+                <a class="no-border" href="http://eepurl.com/yfNtr">
                     <section>
-                        <form action="http://hood.us4.list-manage.com/subscribe/post?u=12d36bbe9418ed6a43127cd62&amp;id=664f4ce8cd" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate=""><input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="Sign up for our Newsletter!" required="">
-                        <input type="submit" value="subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">
-                        </form>
+                        <h3>
+                            Sign up for the Hoodie newsletter!
+                        </h3>
                     </section>
-                </div>
+                </a>
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
The Mailchimp embed isn’t GDPR-compliant, [this page](http://eepurl.com/yfNtr) on the other hand is. The link looks like this:

![bildschirmfoto 2018-05-24 um 17 12 38](https://user-images.githubusercontent.com/391124/40494667-aff7e9a0-5f75-11e8-95ab-7ed675070bfb.png)
